### PR TITLE
.aws/config format not text

### DIFF
--- a/badger-rds-logs.bash
+++ b/badger-rds-logs.bash
@@ -71,6 +71,7 @@ for log in `aws rds describe-db-log-files \
 do
     aws rds download-db-log-file-portion \
 --db-instance-identifier ${RDS_INSTANCE} \
+--output text \
 --log-file-name ${log} >> ${LOG_FILE}
 echo "done with ${log}"
 done


### PR DESCRIPTION
 so you need download-db-log-file-portion ``--output text \`` as well - otherwise pgbadger does not pickup lines (as json formatted with escapes)